### PR TITLE
Accept http.Client in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,28 @@
 # What's this?
 
 go-couchdb is yet another CouchDB client written in Go.
-It was written because all the other ones didn't provide
-functionality that I need.
-
-The API is not fully baked at this time and may change.
+Forked from [github.com/cabify/go-couchdb](http://github.com/cabify/go-couchdb) but not compatible with it anymore.
 
 This project contains three Go packages:
 
-## package couchdb [![GoDoc](https://godoc.org/github.com/fjl/go-couchdb?status.png)](http://godoc.org/github.com/fjl/go-couchdb)
+## package couchdb [![GoDoc](https://godoc.org/github.com/cabify/go-couchdb?status.png)](http://godoc.org/github.com/cabify/go-couchdb)
 
-    import "github.com/fjl/go-couchdb"
+    import "github.com/cabify/go-couchdb"
 
 This wraps the CouchDB HTTP API.
 
-## package couchapp [![GoDoc](https://godoc.org/github.com/fjl/go-couchdb?status.png)](http://godoc.org/github.com/fjl/go-couchdb/couchapp)
+## package couchapp [![GoDoc](https://godoc.org/github.com/cabify/go-couchdb?status.png)](http://godoc.org/github.com/cabify/go-couchdb/couchapp)
 
-    import "github.com/fjl/go-couchdb/couchapp"
+    import "github.com/cabify/go-couchdb/couchapp"
 
 This provides functionality similar to the original
 [couchapp](https://github.com/couchapp/couchapp) tool,
 namely compiling a filesystem directory into a JSON object
 and storing the object as a CouchDB design document.
 
-## package couchdaemon [![GoDoc](https://godoc.org/github.com/fjl/go-couchdb?status.png)](http://godoc.org/github.com/fjl/go-couchdb/couchdaemon)
+## package couchdaemon [![GoDoc](https://godoc.org/github.com/cabify/go-couchdb?status.png)](http://godoc.org/github.com/cabify/go-couchdb/couchdaemon)
 
-    import "github.com/fjl/go-couchdb/couchdaemon"
+    import "github.com/cabify/go-couchdb/couchdaemon"
 
 This package contains some functions that help
 you write Go programs that run as a daemon started by CouchDB,
@@ -35,4 +32,4 @@ e.g. fetching values from the CouchDB config.
 
 You can run the unit tests with `go test`.
 
-[![Build Status](https://travis-ci.org/fjl/go-couchdb.png?branch=master)](https://travis-ci.org/fjl/go-couchdb)
+[![Build Status](https://travis-ci.org/cabify/go-couchdb.png?branch=master)](https://travis-ci.org/cabify/go-couchdb)

--- a/couchdb.go
+++ b/couchdb.go
@@ -16,6 +16,7 @@ import (
 // Client represents a remote CouchDB server.
 type Client struct{ *transport }
 
+// NewClient creates a new Client
 // addr should contain scheme and host, and optionally port and path. All other attributes will be ignored
 // If client is nil, default http.Client will be used
 // If auth is nil, no auth will be set

--- a/couchdb.go
+++ b/couchdb.go
@@ -16,27 +16,14 @@ import (
 // Client represents a remote CouchDB server.
 type Client struct{ *transport }
 
-// NewClient creates a new client object.
-//
-// If rawurl contains credentials, the client will authenticate
-// using HTTP Basic Authentication. If rawurl has a query string,
-// it is ignored.
-//
-// The second argument can be nil to use http.Transport,
-// which should be good enough in most cases.
-func NewClient(rawurl string, rt http.RoundTripper) (*Client, error) {
-	url, err := url.Parse(rawurl)
-	if err != nil {
-		return nil, err
-	}
-	url.RawQuery, url.Fragment = "", ""
-	var auth Auth
-	if url.User != nil {
-		passwd, _ := url.User.Password()
-		auth = BasicAuth(url.User.Username(), passwd)
-		url.User = nil
-	}
-	return &Client{newTransport(url.String(), rt, auth)}, nil
+// addr should contain scheme and host, and optionally port and path. All other attributes will be ignored
+// If client is nil, default http.Client will be used
+// If auth is nil, no auth will be set
+func NewClient(addr *url.URL, client *http.Client, auth Auth) *Client {
+	prefixAddr := *addr
+	// cleanup our address
+	prefixAddr.User, prefixAddr.RawQuery, prefixAddr.Fragment = nil, "", ""
+	return &Client{newTransport(prefixAddr.String(), client, auth) }
 }
 
 // URL returns the URL prefix of the server.

--- a/http.go
+++ b/http.go
@@ -34,10 +34,13 @@ type transport struct {
 	auth   Auth
 }
 
-func newTransport(prefix string, rt http.RoundTripper, auth Auth) *transport {
+func newTransport(prefix string, httpClient *http.Client, auth Auth) *transport {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
 	return &transport{
 		prefix: strings.TrimRight(prefix, "/"),
-		http:   &http.Client{Transport: rt},
+		http:   httpClient,
 		auth:   auth,
 	}
 }

--- a/x_test.go
+++ b/x_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"github.com/cabify/go-couchdb"
 	"io/ioutil"
-	. "net/http"
+	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
@@ -23,18 +23,18 @@ import (
 type testClient struct {
 	*couchdb.Client
 	t        *testing.T
-	handlers map[string]Handler
+	handlers map[string]http.Handler
 }
 
-func (s *testClient) Handle(pat string, f func(ResponseWriter, *Request)) {
-	s.handlers[pat] = HandlerFunc(f)
+func (s *testClient) Handle(pat string, f func(http.ResponseWriter, *http.Request)) {
+	s.handlers[pat] = http.HandlerFunc(f)
 }
 
 func (s *testClient) ClearHandlers() {
-	s.handlers = make(map[string]Handler)
+	s.handlers = make(map[string]http.Handler)
 }
 
-func (s *testClient) RoundTrip(req *Request) (*Response, error) {
+func (s *testClient) RoundTrip(req *http.Request) (*http.Response, error) {
 	handler, ok := s.handlers[req.Method+" "+req.URL.Path]
 	if !ok {
 		s.t.Fatalf("unhandled request: %s %s", req.Method, req.URL.Path)
@@ -43,12 +43,12 @@ func (s *testClient) RoundTrip(req *Request) (*Response, error) {
 	recorder := httptest.NewRecorder()
 	recorder.Body = new(bytes.Buffer)
 	handler.ServeHTTP(recorder, req)
-	resp := &Response{
+	resp := &http.Response{
 		Proto:         "HTTP/1.1",
 		ProtoMajor:    1,
 		ProtoMinor:    1,
 		StatusCode:    recorder.Code,
-		Status:        StatusText(recorder.Code),
+		Status:        http.StatusText(recorder.Code),
 		Header:        recorder.HeaderMap,
 		ContentLength: int64(recorder.Body.Len()),
 		Body:          ioutil.NopCloser(recorder.Body),
@@ -58,11 +58,8 @@ func (s *testClient) RoundTrip(req *Request) (*Response, error) {
 }
 
 func newTestClient(t *testing.T) *testClient {
-	tc := &testClient{t: t, handlers: make(map[string]Handler)}
-	client, err := couchdb.NewClient("http://testClient:5984/", tc)
-	if err != nil {
-		t.Fatalf("couchdb.NewClient returned error: %v", err)
-	}
+	tc := &testClient{t: t, handlers: make(map[string]http.Handler)}
+	client  := couchdb.NewClient(asURL("http://testClient:5984/"), &http.Client{Transport:tc}, nil)
 	tc.Client = client
 	return tc
 }


### PR DESCRIPTION
We need to specify `http.Client`'s timeout so we need to be able to pass the client.

Updated README.md with our package references.