### PR TITLE
Add `keys` to `viewJsonKeys`.

### DIFF
--- a/couchdb.go
+++ b/couchdb.go
@@ -208,7 +208,7 @@ func (db *DB) PutSecurity(secobj *Security) error {
 	return err
 }
 
-var viewJsonKeys = []string{"startkey", "start_key", "key", "endkey", "end_key"}
+var viewJsonKeys = []string{"startkey", "start_key", "key", "endkey", "end_key", "keys"}
 
 // View invokes a view.
 // The ddoc parameter must be the name of the design document


### PR DESCRIPTION
From the CouchDB docs:

> keys (json-array) – Return only documents where the key matches one of
> the keys specified in the array.