### PR TITLE
Added check for gets by empty ID

### DIFF
--- a/couchdb.go
+++ b/couchdb.go
@@ -119,6 +119,9 @@ var getJsonKeys = []string{"open_revs", "atts_since"}
 //
 // http://docs.couchdb.org/en/latest/api/document/common.html?highlight=doc#get--db-docid
 func (db *DB) Get(id string, doc interface{}, opts Options) error {
+	if id == "" {
+		return errorGetByEmptyID()
+	}
 	path, err := optpath(opts, getJsonKeys, db.name, id)
 	if err != nil {
 		return err
@@ -278,4 +281,13 @@ func (db *DB) SyncDesign(d *Design) error {
 		d.Rev = rev
 	}
 	return nil
+}
+
+func errorGetByEmptyID() error {
+	return &Error{
+		Method: "GET",
+		StatusCode: http.StatusNotFound,
+		ErrorCode: "not_found",
+		Reason: "no id provided",
+	}
 }

--- a/couchdb_test.go
+++ b/couchdb_test.go
@@ -215,6 +215,14 @@ func TestGetNonexistingDoc(t *testing.T) {
 	check(t, "couchdb.NotFound(err)", true, couchdb.NotFound(err))
 }
 
+func TestGetDocByEmptyID(t *testing.T) {
+	c := newTestClient(t)
+
+	var doc testDocument
+	err := c.DB("db").Get("", doc, nil)
+	check(t, "couchdb.NotFound(err)", true, couchdb.NotFound(err))
+}
+
 func TestRev(t *testing.T) {
 	c := newTestClient(t)
 	db := c.DB("db")


### PR DESCRIPTION
When empty ID is provided to get, it just makes the request to

http://addr/database/

So CouchDB returns the state of the database instead of an 404 error, and that unmarshals into the provided entity as-it-can (hopefully without common fields so it will just return an empty entity, in the worst case it would write unrelated data into your fields).