### PR TITLE
Fix the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: go
 go:
-  - 1.9
+  - 1.10
+
+script:
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.10
+  - "1.10"
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 .PHONY: test
-test: # Run tests
+test: ## Run tests
 	go test -race ./...
 
 .PHONY: fmt
-fmt: # Fix code formatting
+fmt: ## Fix code formatting
 	go fmt ./...
+
+.PHONY: help
+help: ## Display help
+	awk 'BEGIN { FS=": ##"; } /^[a-zA-Z_-]+: ##/ { printf("%-10s %s\n", $$1, $$2); }' $(MAKEFILE_LIST) | sort
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test
+test: # Run tests
+	go test -race ./...
+
+.PHONY: fmt
+fmt: # Fix code formatting
+	go fmt ./...

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ e.g. fetching values from the CouchDB config.
 
 # Tests
 
-You can run the unit tests with `go test`.
+You can run the unit tests with `make test`.
 
 [![Build Status](https://travis-ci.org/cabify/go-couchdb.png?branch=master)](https://travis-ci.org/cabify/go-couchdb)

--- a/couchapp/couchapp.go
+++ b/couchapp/couchapp.go
@@ -11,7 +11,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/fjl/go-couchdb"
+	"github.com/cabify/go-couchdb"
 	"io/ioutil"
 	"mime"
 	"os"

--- a/couchdaemon/couchdaemon.go
+++ b/couchdaemon/couchdaemon.go
@@ -42,7 +42,7 @@ func Init(exit chan<- struct{}) {
 		if exit == nil {
 			start(os.Stdin, os.Stdout, func() { os.Exit(0) })
 		} else {
-			start(os.Stdin, os.Stdout, func() { os.Exit(0) })
+			start(os.Stdin, os.Stdout, func() { close(exit) })
 		}
 	})
 }

--- a/couchdaemon/couchdaemon_test.go
+++ b/couchdaemon/couchdaemon_test.go
@@ -2,16 +2,15 @@ package couchdaemon
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/json"
 	"io"
 	"reflect"
 	"testing"
 	"time"
-)
+	)
 
 type testHost struct {
-	output   *bytes.Buffer
+	output   chan []byte
 	exitchan chan struct{}
 	config   testConfig
 	outW     io.Closer
@@ -23,7 +22,7 @@ func startTestHost(t *testing.T, config testConfig) *testHost {
 	inR, inW := io.Pipe()   // input stream (testHost writes, daemon reads)
 	outR, outW := io.Pipe() // output stream (testHost reads, daemon writes)
 	th := &testHost{
-		output:   new(bytes.Buffer),
+		output:   make(chan []byte),
 		exitchan: make(chan struct{}),
 		config:   config,
 		outW:     outW,
@@ -39,7 +38,6 @@ func startTestHost(t *testing.T, config testConfig) *testHost {
 				return
 			}
 
-			th.output.Write(line)
 			if err := json.Unmarshal(line, &req); err != nil {
 				t.Errorf("testHost: could not decode request: %v", err)
 				return
@@ -64,6 +62,8 @@ func startTestHost(t *testing.T, config testConfig) *testHost {
 			default:
 				t.Errorf("testHost: unmatched request")
 			}
+
+			th.output <- line
 		}
 	}()
 
@@ -78,26 +78,26 @@ func (th *testHost) stop() {
 
 func TestNotInitialized(t *testing.T) {
 	if _, err := ConfigSection("s"); err != ErrNotInitialized {
-		t.Errorf("ConfigSection err mismatch, got %v, want ErrNotInitialized")
+		t.Errorf("ConfigSection err mismatch, got %v, want ErrNotInitialized", err)
 	}
 	if _, err := ConfigVal("s", "k"); err != ErrNotInitialized {
-		t.Errorf("ConfigVal err mismatch, got %v, want ErrNotInitialized")
+		t.Errorf("ConfigVal err mismatch, got %v, want ErrNotInitialized", err)
 	}
 	if _, err := ServerURL(); err != ErrNotInitialized {
-		t.Errorf("ServerURL err mismatch, got %v, want ErrNotInitialized")
+		t.Errorf("ServerURL err mismatch, got %v, want ErrNotInitialized", err)
 	}
 	log := NewLogWriter()
 	if _, err := log.Write([]byte("foo")); err != ErrNotInitialized {
-		t.Errorf("log.Write err mismatch, got %v, want ErrNotInitialized")
+		t.Errorf("log.Write err mismatch, got %v, want ErrNotInitialized", err)
 	}
 	if err := log.Err("foo"); err != ErrNotInitialized {
-		t.Errorf("log.Err err mismatch, got %v, want ErrNotInitialized")
+		t.Errorf("log.Err err mismatch, got %v, want ErrNotInitialized", err)
 	}
 	if err := log.Info("foo"); err != ErrNotInitialized {
-		t.Errorf("log.Info err mismatch, got %v, want ErrNotInitialized")
+		t.Errorf("log.Info err mismatch, got %v, want ErrNotInitialized", err)
 	}
 	if err := log.Debug("foo"); err != ErrNotInitialized {
-		t.Errorf("log.Debug err mismatch, got %v, want ErrNotInitialized")
+		t.Errorf("log.Debug err mismatch, got %v, want ErrNotInitialized", err)
 	}
 }
 
@@ -115,8 +115,9 @@ func TestLogWrite(t *testing.T) {
 	if n != len(msg) {
 		t.Errorf("short write: %v != %v", n, len(msg))
 	}
-	if th.output.String() != `["log","a\"bc"]`+"\n" {
-		t.Errorf("wrong JSON output: %s", th.output.String())
+
+	if res := <-th.output; string(res) != `["log","a\"bc"]`+"\n" {
+		t.Errorf("wrong JSON output: %s", res)
 	}
 }
 
@@ -128,7 +129,7 @@ func TestLogWriteError(t *testing.T) {
 
 	log := NewLogWriter()
 	if _, err := log.Write([]byte("msg")); err != io.ErrClosedPipe {
-		t.Errorf(`log.Write("msg") err mismatch, got %v, want io.ErrClosedPipe`)
+		t.Errorf(`log.Write("msg") err mismatch, got %v, want io.ErrClosedPipe`, err)
 	}
 }
 
@@ -147,12 +148,11 @@ func TestLogLevels(t *testing.T) {
 	}
 
 	for _, testcase := range cases {
-		th.output.Reset()
 		if err := testcase.method("msg"); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if th.output.String() != testcase.output+"\n" {
-			t.Errorf("wrong JSON output: %s", th.output.String())
+		if res := <-th.output; string(res) != testcase.output+"\n" {
+			t.Errorf("wrong JSON output: %s", res)
 		}
 	}
 }
@@ -171,8 +171,8 @@ func TestConfigVal(t *testing.T) {
 	if val != expVal {
 		t.Errorf(`ConfigVal("a", "b") got: %q, want: %q`, val, expVal)
 	}
-	if th.output.String() != `["get","a","b"]`+"\n" {
-		t.Errorf("wrong JSON output: %q", th.output.String())
+	if res := <-th.output; string(res) != `["get","a","b"]`+"\n" {
+		t.Errorf("wrong JSON output: %q", res)
 	}
 }
 
@@ -221,8 +221,8 @@ func TestConfigSection(t *testing.T) {
 	if !reflect.DeepEqual(val, expVal) {
 		t.Errorf(`ConfigSection("section1") got: %v, want %v`, val, expVal)
 	}
-	if th.output.String() != `["get","section1"]`+"\n" {
-		t.Errorf("wrong JSON output: %q", th.output.String())
+	if res := <-th.output; string(res) != `["get","section1"]`+"\n" {
+		t.Errorf("wrong JSON output: %q", res)
 	}
 }
 
@@ -262,6 +262,13 @@ func TestServerURL(t *testing.T) {
 	defer th.stop()
 
 	expVal := "http://127.0.0.1:5984/"
+
+	go func() {
+		// Discard the two output results
+		<-th.output
+		<-th.output
+	} ()
+
 	respurl, err := ServerURL()
 	if err != nil {
 		t.Fatalf("ServerURL() returned error: %v", err)

--- a/couchdaemon/couchdaemon_test.go
+++ b/couchdaemon/couchdaemon_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 	"time"
-	)
+)
 
 type testHost struct {
 	output   chan []byte
@@ -267,7 +267,7 @@ func TestServerURL(t *testing.T) {
 		// Discard the two output results
 		<-th.output
 		<-th.output
-	} ()
+	}()
 
 	respurl, err := ServerURL()
 	if err != nil {

--- a/x_test.go
+++ b/x_test.go
@@ -59,7 +59,7 @@ func (s *testClient) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func newTestClient(t *testing.T) *testClient {
 	tc := &testClient{t: t, handlers: make(map[string]http.Handler)}
-	client  := couchdb.NewClient(asURL("http://testClient:5984/"), &http.Client{Transport:tc}, nil)
+	client := couchdb.NewClient(asURL("http://testClient:5984/"), &http.Client{Transport: tc}, nil)
 	tc.Client = client
 	return tc
 }


### PR DESCRIPTION
- Tests were race dependent, depending on whether the result was checked or the buffer was written to first.
- Adds a Makefile to standardise running tests. 
- Small change to close the exit channel when a channel is providing as indicates the godoc. 
- Fix formatting.
- Bumps the go version.
- Adds running the tests to travis.