### PR TITLE
Add context support

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,86 @@
+package couchdb
+
+import (
+	"net/url"
+	"net/http"
+	"fmt"
+)
+
+// Client represents a remote CouchDB server.
+type Client struct{ *transport }
+
+// NewClient creates a new Client
+// addr should contain scheme and host, and optionally port and path. All other attributes will be ignored
+// If client is nil, default http.Client will be used
+// If auth is nil, no auth will be set
+func NewClient(addr *url.URL, client *http.Client, auth Auth) *Client {
+	prefixAddr := *addr
+	// cleanup our address
+	prefixAddr.User, prefixAddr.RawQuery, prefixAddr.Fragment = nil, "", ""
+	return &Client{newTransport(prefixAddr.String(), client, auth)}
+}
+
+// URL returns the URL prefix of the server.
+// The url will not contain a trailing '/'.
+func (c *Client) URL() string {
+	return c.prefix
+}
+
+// Ping can be used to check whether a server is alive.
+// It sends an HTTP HEAD request to the server's URL.
+func (c *Client) Ping() error {
+	_, err := c.closedRequest("HEAD", "/", nil)
+	return err
+}
+
+// SetAuth sets the authentication mechanism used by the client.
+// Use SetAuth(nil) to unset any mechanism that might be in use.
+// In order to verify the credentials against the server, issue any request
+// after the call the SetAuth.
+func (c *Client) SetAuth(a Auth) {
+	c.transport.setAuth(a)
+}
+
+// CreateDB creates a new database.
+// The request will fail with status "412 Precondition Failed" if the database
+// already exists. A valid DB object is returned in all cases, even if the
+// request fails.
+func (c *Client) CreateDB(name string) (*DB, error) {
+	if _, err := c.closedRequest("PUT", path(name), nil); err != nil {
+		return c.DB(name), err
+	}
+	return c.DB(name), nil
+}
+
+// CreateDBWithShards creates a new database with the specified number of shards
+func (c *Client) CreateDBWithShards(name string, shards int) (*DB, error) {
+	_, err := c.closedRequest("PUT", fmt.Sprintf("%s?q=%d", path(name), shards), nil)
+
+	return c.DB(name), err
+}
+
+// EnsureDB ensures that a database with the given name exists.
+func (c *Client) EnsureDB(name string) (*DB, error) {
+	db, err := c.CreateDB(name)
+	if err != nil && !ErrorStatus(err, http.StatusPreconditionFailed) {
+		return nil, err
+	}
+	return db, nil
+}
+
+// DeleteDB deletes an existing database.
+func (c *Client) DeleteDB(name string) error {
+	_, err := c.closedRequest("DELETE", path(name), nil)
+	return err
+}
+
+// AllDBs returns the names of all existing databases.
+func (c *Client) AllDBs() (names []string, err error) {
+	resp, err := c.request("GET", "/_all_dbs", nil)
+	if err != nil {
+		return names, err
+	}
+	err = readBody(resp, &names)
+	return names, err
+}
+

--- a/client.go
+++ b/client.go
@@ -88,8 +88,8 @@ func (c *ContextAwareClient) AllDBs(ctx context.Context) (names []string, err er
 // DB creates a database object.
 // The database inherits the authentication and http.RoundTripper
 // of the client. The database's actual existence is not verified.
-func (c *ContextAwareClient) DB(name string) *DB {
-	return &DB{c.transport, name}
+func (c *ContextAwareClient) DB(name string) *ContextAwareDB {
+	return &ContextAwareDB{c.transport, name}
 }
 
 // Deprecated: Use ContextAwareClient
@@ -103,4 +103,4 @@ func (c *Client) CreateDBWithShards(name string, shards int) (*DB, error) { retu
 func (c *Client) EnsureDB(name string) (*DB, error) { return c.c.EnsureDB(context.Background(), name) }
 func (c *Client) DeleteDB(name string) error { return c.c.DeleteDB(context.Background(), name) }
 func (c *Client) AllDBs() (names []string, err error) { return c.c.AllDBs(context.Background()) }
-func (c *Client) DB(name string) *DB { return c.c.DB(name) }
+func (c *Client) DB(name string) *DB { return &DB{db: c.c.DB(name)} }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,109 @@
+package couchdb_test
+
+import (
+	"testing"
+	"net/url"
+	"net/http"
+	"errors"
+	"io"
+	"github.com/cabify/go-couchdb"
+)
+
+func TestNewClient(t *testing.T) {
+	tests := []struct {
+		URL                         *url.URL
+		Auth                        couchdb.Auth
+		SetAuth                     couchdb.Auth
+		ExpectURL, ExpectAuthHeader string
+	}{
+		// No Auth
+		{
+			URL:       asURL("http://127.0.0.1:5984/"),
+			ExpectURL: "http://127.0.0.1:5984",
+		},
+		{
+			URL:       asURL("http://hostname:5984/foobar?query=1"),
+			ExpectURL: "http://hostname:5984/foobar",
+		},
+		// Credentials in URL
+		{
+			URL:              asURL("http://user:password@hostname:5984/"),
+			ExpectURL:        "http://hostname:5984",
+			Auth:             couchdb.BasicAuth("user", "password"),
+			ExpectAuthHeader: "Basic dXNlcjpwYXNzd29yZA==",
+		},
+		// Credentials in URL and explicit SetAuth, SetAuth credentials win
+		{
+			URL:              asURL("http://urluser:urlpassword@hostname:5984/"),
+			SetAuth:          couchdb.BasicAuth("user", "password"),
+			ExpectURL:        "http://hostname:5984",
+			ExpectAuthHeader: "Basic dXNlcjpwYXNzd29yZA==",
+		},
+	}
+
+	for i, test := range tests {
+		rt := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			a := r.Header.Get("Authorization")
+			if a != test.ExpectAuthHeader {
+				t.Errorf("test %d: auth header mismatch: got %q, want %q", i, a, test.ExpectAuthHeader)
+			}
+			return nil, errors.New("nothing to see here, move along")
+		})
+		httpClient := &http.Client{Transport: rt}
+		c := couchdb.NewClient(test.URL, httpClient, test.Auth)
+		if c.URL() != test.ExpectURL {
+			t.Errorf("test %d: ServerURL mismatch: got %q, want %q", i, c.URL(), test.ExpectURL)
+		}
+		if test.SetAuth != nil {
+			c.SetAuth(test.SetAuth)
+		}
+		c.Ping() // trigger round trip
+	}
+}
+
+func TestServerURL(t *testing.T) {
+	c := newTestClient(t)
+	check(t, "c.URL()", "http://testClient:5984", c.URL())
+}
+
+func TestPing(t *testing.T) {
+	c := newTestClient(t)
+	c.Handle("HEAD /", func(resp http.ResponseWriter, req *http.Request) {})
+
+	if err := c.Ping(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCreateDB(t *testing.T) {
+	c := newTestClient(t)
+	c.Handle("PUT /db", func(resp http.ResponseWriter, req *http.Request) {})
+
+	db, err := c.CreateDB("db")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	check(t, "db.Name()", "db", db.Name())
+}
+
+func TestDeleteDB(t *testing.T) {
+	c := newTestClient(t)
+	c.Handle("DELETE /db", func(resp http.ResponseWriter, req *http.Request) {})
+	if err := c.DeleteDB("db"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAllDBs(t *testing.T) {
+	c := newTestClient(t)
+	c.Handle("GET /_all_dbs", func(resp http.ResponseWriter, req *http.Request) {
+		io.WriteString(resp, `["a","b","c"]`)
+	})
+
+	names, err := c.AllDBs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	check(t, "returned names", []string{"a", "b", "c"}, names)
+}

--- a/couchapp/couchapp.go
+++ b/couchapp/couchapp.go
@@ -11,7 +11,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/fjl/go-couchdb"
+	"github.com/cabify/go-couchdb"
 	"io/ioutil"
 	"mime"
 	"os"

--- a/couchdb.go
+++ b/couchdb.go
@@ -8,20 +8,21 @@ import (
 	"bytes"
 	"encoding/json"
 	"strings"
+	"context"
 )
 
-// DB represents a remote CouchDB database.
-type DB struct {
+var getJsonKeys = []string{"open_revs", "atts_since"}
+
+// ContextAwareDB represents a remote CouchDB database.
+type ContextAwareDB struct {
 	*transport
 	name string
 }
 
 // Name returns the name of a database.
-func (db *DB) Name() string {
+func (db *ContextAwareDB) Name() string {
 	return db.name
 }
-
-var getJsonKeys = []string{"open_revs", "atts_since"}
 
 // Get retrieves a document from the given database.
 // The document is unmarshalled into the given object.
@@ -30,12 +31,12 @@ var getJsonKeys = []string{"open_revs", "atts_since"}
 // for more information.
 //
 // http://docs.couchdb.org/en/latest/api/document/common.html?highlight=doc#get--db-docid
-func (db *DB) Get(id string, doc interface{}, opts Options) error {
+func (db *ContextAwareDB) Get(ctx context.Context, id string, doc interface{}, opts Options) error {
 	path, err := optpath(opts, getJsonKeys, db.name, id)
 	if err != nil {
 		return err
 	}
-	resp, err := db.request("GET", path, nil)
+	resp, err := db.request(ctx, "GET", path, nil)
 	if err != nil {
 		return err
 	}
@@ -45,12 +46,12 @@ func (db *DB) Get(id string, doc interface{}, opts Options) error {
 // Rev fetches the current revision of a document.
 // It is faster than an equivalent Get request because no body
 // has to be parsed.
-func (db *DB) Rev(id string) (string, error) {
-	return responseRev(db.closedRequest("HEAD", path(db.name, id), nil))
+func (db *ContextAwareDB) Rev(ctx context.Context, id string) (string, error) {
+	return responseRev(db.closedRequest(ctx, "HEAD", path(db.name, id), nil))
 }
 
 // Post stores a new document into the given database.
-func (db *DB) Post(doc interface{}) (id, rev string, err error) {
+func (db *ContextAwareDB) Post(ctx context.Context, doc interface{}) (id, rev string, err error) {
 	path := revpath("", db.name)
 	// TODO: make it possible to stream encoder output somehow
 	json, err := json.Marshal(doc)
@@ -58,7 +59,7 @@ func (db *DB) Post(doc interface{}) (id, rev string, err error) {
 		return "", "", err
 	}
 	b := bytes.NewReader(json)
-	resp, err := db.request("POST", path, b)
+	resp, err := db.request(ctx, "POST", path, b)
 	if err != nil {
 		return "", "", err
 	}
@@ -66,7 +67,7 @@ func (db *DB) Post(doc interface{}) (id, rev string, err error) {
 }
 
 // Put stores a document into the given database.
-func (db *DB) Put(id string, doc interface{}, rev string) (newrev string, err error) {
+func (db *ContextAwareDB) Put(ctx context.Context, id string, doc interface{}, rev string) (newrev string, err error) {
 	path := revpath(rev, db.name, id)
 	// TODO: make it possible to stream encoder output somehow
 	json, err := json.Marshal(doc)
@@ -74,13 +75,13 @@ func (db *DB) Put(id string, doc interface{}, rev string) (newrev string, err er
 		return "", err
 	}
 	b := bytes.NewReader(json)
-	return responseRev(db.closedRequest("PUT", path, b))
+	return responseRev(db.closedRequest(ctx, "PUT", path, b))
 }
 
 // Delete marks a document revision as deleted.
-func (db *DB) Delete(id, rev string) (newrev string, err error) {
+func (db *ContextAwareDB) Delete(ctx context.Context, id, rev string) (newrev string, err error) {
 	path := revpath(rev, db.name, id)
-	return responseRev(db.closedRequest("DELETE", path, nil))
+	return responseRev(db.closedRequest(ctx, "DELETE", path, nil))
 }
 
 // Security represents database security objects.
@@ -96,9 +97,9 @@ type Members struct {
 }
 
 // Security retrieves the security object of a database.
-func (db *DB) Security() (*Security, error) {
+func (db *ContextAwareDB) Security(ctx context.Context) (*Security, error) {
 	secobj := new(Security)
-	resp, err := db.request("GET", path(db.name, "_security"), nil)
+	resp, err := db.request(ctx, "GET", path(db.name, "_security"), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -113,10 +114,10 @@ func (db *DB) Security() (*Security, error) {
 }
 
 // PutSecurity sets the database security object.
-func (db *DB) PutSecurity(secobj *Security) error {
+func (db *ContextAwareDB) PutSecurity(ctx context.Context, secobj *Security) error {
 	json, _ := json.Marshal(secobj)
 	body := bytes.NewReader(json)
-	_, err := db.request("PUT", path(db.name, "_security"), body)
+	_, err := db.request(ctx, "PUT", path(db.name, "_security"), body)
 	return err
 }
 
@@ -132,13 +133,13 @@ var viewJsonKeys = []string{"startkey", "start_key", "key", "endkey", "end_key",
 // options that can be set.
 //
 // http://docs.couchdb.org/en/latest/api/ddoc/views.html
-func (db *DB) View(ddoc, view string, result interface{}, opts Options) error {
+func (db *ContextAwareDB) View(ctx context.Context, ddoc, view string, result interface{}, opts Options) error {
 	ddoc = strings.Replace(ddoc, "_design/", "", 1)
 	path, err := optpath(opts, viewJsonKeys, db.name, "_design", ddoc, "_view", view)
 	if err != nil {
 		return err
 	}
-	resp, err := db.request("GET", path, nil)
+	resp, err := db.request(ctx, "GET", path, nil)
 	if err != nil {
 		return err
 	}
@@ -153,12 +154,12 @@ func (db *DB) View(ddoc, view string, result interface{}, opts Options) error {
 // options that can be set.
 //
 // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#db-all-docs
-func (db *DB) AllDocs(result interface{}, opts Options) error {
+func (db *ContextAwareDB) AllDocs(ctx context.Context, result interface{}, opts Options) error {
 	path, err := optpath(opts, viewJsonKeys, db.name, "_all_docs")
 	if err != nil {
 		return err
 	}
-	resp, err := db.request("GET", path, nil)
+	resp, err := db.request(ctx, "GET", path, nil)
 	if err != nil {
 		return err
 	}
@@ -168,10 +169,10 @@ func (db *DB) AllDocs(result interface{}, opts Options) error {
 // SyncDesign will attempt to create or update a design document on the provided
 // database. This can be called multiple times for different databases,
 // the latest Rev will always be fetched before storing the design.
-func (db *DB) SyncDesign(d *Design) error {
+func (db *ContextAwareDB) SyncDesign(ctx context.Context, d *Design) error {
 	// Get the previous design doc so we can compare and extract Rev if needed
 	prev := &Design{}
-	if err := db.Get(d.ID, prev, nil); err != nil {
+	if err := db.Get(ctx, d.ID, prev, nil); err != nil {
 		if !NotFound(err) {
 			return err
 		}
@@ -184,10 +185,27 @@ func (db *DB) SyncDesign(d *Design) error {
 		}
 	}
 	d.Rev = "" // Prevent conflicts when switching databases
-	if rev, err := db.Put(d.ID, d, prev.Rev); err != nil {
+	if rev, err := db.Put(ctx, d.ID, d, prev.Rev); err != nil {
 		return err
 	} else {
 		d.Rev = rev
 	}
 	return nil
 }
+
+// Deprecated: Use ContextAwareDB
+type DB struct {
+	db *ContextAwareDB
+}
+
+func (db *DB) Name() string { return db.db.Name() }
+func (db *DB) Get(id string, doc interface{}, opts Options) error {return db.db.Get(context.Background(), id, doc, opts)}
+func (db *DB) Rev(id string) (string, error) { return db.db.Rev(context.Background(), id)}
+func (db *DB) Post(doc interface{}) (id, rev string, err error) {return db.db.Post(context.Background(), doc)}
+func (db *DB) Put(id string, doc interface{}, rev string) (newrev string, err error) {return db.db.Put(context.Background(), id, doc, rev)}
+func (db *DB) Delete(id, rev string) (newrev string, err error) {return db.db.Delete(context.Background(), id, rev)}
+func (db *DB) Security() (*Security, error) { return db.db.Security(context.Background()) }
+func (db *DB) PutSecurity(secobj *Security) error { return db.db.PutSecurity(context.Background(), secobj) }
+func (db *DB) View(ddoc, view string, result interface{}, opts Options) error { return db.db.View(context.Background(), ddoc, view, result, opts) }
+func (db *DB) AllDocs(result interface{}, opts Options) error { return db.db.AllDocs(context.Background(), result, opts)}
+func (db *DB) SyncDesign(d *Design) error { return db.db.SyncDesign(context.Background(), d)}

--- a/couchdb.go
+++ b/couchdb.go
@@ -16,13 +16,6 @@ type DB struct {
 	name string
 }
 
-// DB creates a database object.
-// The database inherits the authentication and http.RoundTripper
-// of the client. The database's actual existence is not verified.
-func (c *Client) DB(name string) *DB {
-	return &DB{c.transport, name}
-}
-
 // Name returns the name of a database.
 func (db *DB) Name() string {
 	return db.name

--- a/couchdb.go
+++ b/couchdb.go
@@ -7,89 +7,8 @@ package couchdb
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"net/http"
-	"net/url"
 	"strings"
 )
-
-// Client represents a remote CouchDB server.
-type Client struct{ *transport }
-
-// NewClient creates a new Client
-// addr should contain scheme and host, and optionally port and path. All other attributes will be ignored
-// If client is nil, default http.Client will be used
-// If auth is nil, no auth will be set
-func NewClient(addr *url.URL, client *http.Client, auth Auth) *Client {
-	prefixAddr := *addr
-	// cleanup our address
-	prefixAddr.User, prefixAddr.RawQuery, prefixAddr.Fragment = nil, "", ""
-	return &Client{newTransport(prefixAddr.String(), client, auth)}
-}
-
-// URL returns the URL prefix of the server.
-// The url will not contain a trailing '/'.
-func (c *Client) URL() string {
-	return c.prefix
-}
-
-// Ping can be used to check whether a server is alive.
-// It sends an HTTP HEAD request to the server's URL.
-func (c *Client) Ping() error {
-	_, err := c.closedRequest("HEAD", "/", nil)
-	return err
-}
-
-// SetAuth sets the authentication mechanism used by the client.
-// Use SetAuth(nil) to unset any mechanism that might be in use.
-// In order to verify the credentials against the server, issue any request
-// after the call the SetAuth.
-func (c *Client) SetAuth(a Auth) {
-	c.transport.setAuth(a)
-}
-
-// CreateDB creates a new database.
-// The request will fail with status "412 Precondition Failed" if the database
-// already exists. A valid DB object is returned in all cases, even if the
-// request fails.
-func (c *Client) CreateDB(name string) (*DB, error) {
-	if _, err := c.closedRequest("PUT", path(name), nil); err != nil {
-		return c.DB(name), err
-	}
-	return c.DB(name), nil
-}
-
-// CreateDBWithShards creates a new database with the specified number of shards
-func (c *Client) CreateDBWithShards(name string, shards int) (*DB, error) {
-	_, err := c.closedRequest("PUT", fmt.Sprintf("%s?q=%d", path(name), shards), nil)
-
-	return c.DB(name), err
-}
-
-// EnsureDB ensures that a database with the given name exists.
-func (c *Client) EnsureDB(name string) (*DB, error) {
-	db, err := c.CreateDB(name)
-	if err != nil && !ErrorStatus(err, http.StatusPreconditionFailed) {
-		return nil, err
-	}
-	return db, nil
-}
-
-// DeleteDB deletes an existing database.
-func (c *Client) DeleteDB(name string) error {
-	_, err := c.closedRequest("DELETE", path(name), nil)
-	return err
-}
-
-// AllDBs returns the names of all existing databases.
-func (c *Client) AllDBs() (names []string, err error) {
-	resp, err := c.request("GET", "/_all_dbs", nil)
-	if err != nil {
-		return names, err
-	}
-	err = readBody(resp, &names)
-	return names, err
-}
 
 // DB represents a remote CouchDB database.
 type DB struct {

--- a/couchdb_test.go
+++ b/couchdb_test.go
@@ -1,8 +1,7 @@
 package couchdb_test
 
 import (
-	"errors"
-	"io"
+		"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -18,104 +17,6 @@ func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
 
-func TestNewClient(t *testing.T) {
-	tests := []struct {
-		URL                         *url.URL
-		Auth                        couchdb.Auth
-		SetAuth                     couchdb.Auth
-		ExpectURL, ExpectAuthHeader string
-	}{
-		// No Auth
-		{
-			URL:       asURL("http://127.0.0.1:5984/"),
-			ExpectURL: "http://127.0.0.1:5984",
-		},
-		{
-			URL:       asURL("http://hostname:5984/foobar?query=1"),
-			ExpectURL: "http://hostname:5984/foobar",
-		},
-		// Credentials in URL
-		{
-			URL:              asURL("http://user:password@hostname:5984/"),
-			ExpectURL:        "http://hostname:5984",
-			Auth:             couchdb.BasicAuth("user", "password"),
-			ExpectAuthHeader: "Basic dXNlcjpwYXNzd29yZA==",
-		},
-		// Credentials in URL and explicit SetAuth, SetAuth credentials win
-		{
-			URL:              asURL("http://urluser:urlpassword@hostname:5984/"),
-			SetAuth:          couchdb.BasicAuth("user", "password"),
-			ExpectURL:        "http://hostname:5984",
-			ExpectAuthHeader: "Basic dXNlcjpwYXNzd29yZA==",
-		},
-	}
-
-	for i, test := range tests {
-		rt := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-			a := r.Header.Get("Authorization")
-			if a != test.ExpectAuthHeader {
-				t.Errorf("test %d: auth header mismatch: got %q, want %q", i, a, test.ExpectAuthHeader)
-			}
-			return nil, errors.New("nothing to see here, move along")
-		})
-		httpClient := &http.Client{Transport: rt}
-		c := couchdb.NewClient(test.URL, httpClient, test.Auth)
-		if c.URL() != test.ExpectURL {
-			t.Errorf("test %d: ServerURL mismatch: got %q, want %q", i, c.URL(), test.ExpectURL)
-		}
-		if test.SetAuth != nil {
-			c.SetAuth(test.SetAuth)
-		}
-		c.Ping() // trigger round trip
-	}
-}
-
-func TestServerURL(t *testing.T) {
-	c := newTestClient(t)
-	check(t, "c.URL()", "http://testClient:5984", c.URL())
-}
-
-func TestPing(t *testing.T) {
-	c := newTestClient(t)
-	c.Handle("HEAD /", func(resp http.ResponseWriter, req *http.Request) {})
-
-	if err := c.Ping(); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestCreateDB(t *testing.T) {
-	c := newTestClient(t)
-	c.Handle("PUT /db", func(resp http.ResponseWriter, req *http.Request) {})
-
-	db, err := c.CreateDB("db")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	check(t, "db.Name()", "db", db.Name())
-}
-
-func TestDeleteDB(t *testing.T) {
-	c := newTestClient(t)
-	c.Handle("DELETE /db", func(resp http.ResponseWriter, req *http.Request) {})
-	if err := c.DeleteDB("db"); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestAllDBs(t *testing.T) {
-	c := newTestClient(t)
-	c.Handle("GET /_all_dbs", func(resp http.ResponseWriter, req *http.Request) {
-		io.WriteString(resp, `["a","b","c"]`)
-	})
-
-	names, err := c.AllDBs()
-	if err != nil {
-		t.Fatal(err)
-	}
-	check(t, "returned names", []string{"a", "b", "c"}, names)
-}
 
 // those are re-used across several tests
 var securityObjectJSON = regexp.MustCompile("\\s").ReplaceAllString(

--- a/http.go
+++ b/http.go
@@ -61,6 +61,16 @@ func (t *transport) addAuth(req *http.Request) *http.Request {
 	return req
 }
 
+func (t *transport) newRequest(method, path string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, t.prefix+path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	t.addAuth(req)
+	return req, nil
+}
+
 // request sends an HTTP request to a CouchDB server.
 // The request URL is constructed from the server's
 // prefix and the given path, which may contain an
@@ -68,12 +78,11 @@ func (t *transport) addAuth(req *http.Request) *http.Request {
 //
 // Status codes >= 400 are treated as errors.
 func (t *transport) request(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest(method, t.prefix+path, body)
+	req, err := t.newRequest(method, t.prefix+path, body)
 	if err != nil {
 		return nil, err
 	}
 
-	t.addAuth(req)
 	req.WithContext(ctx)
 
 	if method != "GET" {

--- a/http.go
+++ b/http.go
@@ -78,7 +78,7 @@ func (t *transport) newRequest(method, path string, body io.Reader) (*http.Reque
 //
 // Status codes >= 400 are treated as errors.
 func (t *transport) request(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
-	req, err := t.newRequest(method, t.prefix+path, body)
+	req, err := t.newRequest(method, path, body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Pass context to couch HTTP requests. Anything request scoped should take context as its first parameter. This enables better control of request cancellation following context deadlines and timeouts. Also allows for handling of data stored in context which can now be read by custom transports in the http client, e.g. for tracing.

This is backwards compatible by defining new ContextAware types but deprecates the interface where context is not used.