### PR TITLE
Add bulk get operation

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -18,8 +18,8 @@ type errorWrapper struct {
 }
 
 type docWrapper struct {
-	Ok    *json.RawMessage `json:"ok"`
-	Error *errorWrapper    `json:"error"`
+	Ok    json.RawMessage `json:"ok"`
+	Error *errorWrapper   `json:"error"`
 }
 
 type bulkRes struct {

--- a/bulk.go
+++ b/bulk.go
@@ -1,0 +1,32 @@
+package couchdb
+
+import "encoding/json"
+
+type bulkID struct {
+	ID string `json:"id"`
+}
+
+type BulkGet struct {
+	Docs []struct{ ID string } `json:"docs"`
+}
+
+type errorWrapper struct {
+	ID     string `json:"id"`
+	Rev    string `json:"rev"`
+	Error  string `json:"error"`
+	Reason string `json:"reason"`
+}
+
+type docWrapper struct {
+	Ok    *json.RawMessage `json:"ok"`
+	Error *errorWrapper    `json:"error"`
+}
+
+type bulkRes struct {
+	Id   string       `json:"id"`
+	Docs []docWrapper `json:"docs"`
+}
+
+type bulkResp struct {
+	Results []bulkRes
+}

--- a/client_test.go
+++ b/client_test.go
@@ -246,12 +246,12 @@ func TestBulkGet(t *testing.T) {
 			{"id":"baz","docs":[{"error":{"id":"baz","rev":"undefined","error":"not_found","reason":"missing"}}]}]}`)
 	})
 
-	docs, notFound, err := c.DB("db").BulkGet([]string{"foo", "bar", "baz"}, &testDocument{}, nil)
+	docs, notFound, err := c.DB("db").BulkGet([]string{"foo", "bar", "baz"}, testDocument{}, nil)
 	check(t, "err", nil, err)
 	check(t, "notFound", []string{"baz"}, notFound)
 
 	for _, doc := range docs {
-		document := doc.(*testDocument)
+		document := doc.(testDocument)
 		switch document.ID {
 		case "foo":
 			check(t, "foo.Rev", "4-753875d51501a6b1883a9d62b4d33f91", document.Rev)

--- a/client_test.go
+++ b/client_test.go
@@ -250,17 +250,25 @@ func TestBulkGet(t *testing.T) {
 	check(t, "err", nil, err)
 	check(t, "notFound", []string{"baz"}, notFound)
 
+	var fooDoc testDocument
+	var barDoc testDocument
+
 	for _, doc := range docs {
 		document := doc.(testDocument)
 		switch document.ID {
 		case "foo":
-			check(t, "foo.Rev", "4-753875d51501a6b1883a9d62b4d33f91", document.Rev)
-			check(t, "foo.Field", 1, document.Field)
+			fooDoc = document
 		case "bar":
-			check(t, "foo.Rev", "2-9b71d36dfdd9b4815388eb91cc8fb61d", document.Rev)
-			check(t, "foo.Field", 2, document.Field)
+			barDoc = document
 		}
 	}
+	check(t, "fooDoc.ID", "foo", fooDoc.ID)
+	check(t, "fooDoc.Rev", "4-753875d51501a6b1883a9d62b4d33f91", fooDoc.Rev)
+	check(t, "fooDoc.Field", 1, fooDoc.Field)
+
+	check(t, "barDoc.ID", "bar", barDoc.ID)
+	check(t, "barDoc.Rev", "2-9b71d36dfdd9b4815388eb91cc8fb61d", barDoc.Rev)
+	check(t, "barDoc.Field", 2, barDoc.Field)
 }
 
 func TestRev(t *testing.T) {

--- a/db.go
+++ b/db.go
@@ -96,7 +96,7 @@ func (db *DB) BulkGet(ids []string, docType interface{}, opts Options) (docs []i
 			if wrapper.Error != nil || wrapper.Ok == nil {
 				notFound = append(notFound, result.Id)
 			} else if wrapper.Ok != nil {
-				err := json.Unmarshal(*wrapper.Ok, docType)
+				err := json.Unmarshal(wrapper.Ok, docType)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/db.go
+++ b/db.go
@@ -61,6 +61,53 @@ func (db *DB) Get(id string, doc interface{}, opts Options) error {
 	return readBody(resp, &doc)
 }
 
+// BulkGet retrieves several documents by their ID.
+// It accepts a list of ID, a pointer to a struct acting as a response type and an Options struct.
+// It returns the list of found docs as a []interface{}, the list of docs not found as a []string and an eventual error.
+// The found docs should be casted to the same type of docType
+func (db *DB) BulkGet(ids []string, docType interface{}, opts Options) (docs []interface{}, notFound []string, err error) {
+	path, err := optpath(opts, getJsonKeys, db.name, "_bulk_get")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	request := &BulkGet{}
+	for _, id := range ids {
+		request.Docs = append(request.Docs, struct{ ID string }{ID: id})
+	}
+
+	bodyJson, err := json.Marshal(request)
+	body := bytes.NewReader(bodyJson)
+
+	resp, err := db.request(db.ctx, "POST", path, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	response := bulkResp{}
+	err = readBody(resp, &response)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, result := range response.Results {
+		if len(result.Docs) > 0 {
+			wrapper := result.Docs[0]
+			if wrapper.Error != nil || wrapper.Ok == nil {
+				notFound = append(notFound, result.Id)
+			} else if wrapper.Ok != nil {
+				err := json.Unmarshal(*wrapper.Ok, docType)
+				if err != nil {
+					return nil, nil, err
+				}
+				docs = append(docs, docType)
+			}
+		}
+	}
+
+	return docs, notFound, nil
+}
+
 // Rev fetches the current revision of a document.
 // It is faster than an equivalent Get request because no body
 // has to be parsed.


### PR DESCRIPTION
As documented in https://docs.couchdb.org/en/stable/api/database/bulk-api.html?highlight=bulk%20fetch#db-bulk-get

Does not explicitely handle `revs` query param. It can be specified but target struct should have a field mapped to `_revisions` json field and of type `[]string`