### PR TITLE
Use xerror to check errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Cabify CouchDB Library ChangeLog
 
+## 0.2.1
+- Using xerrors for error detection
+
 ## 0.2.0
 ### Added
 - BulkGet method to query multiple documents per id at once

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/cabify/go-couchdb
 
 go 1.12
+
+require golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/http.go
+++ b/http.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"golang.org/x/xerrors"
 )
 
 // Options represents CouchDB query string parameters.
@@ -270,8 +272,11 @@ func Conflict(err error) bool {
 // ErrorStatus checks whether the given error is a DatabaseError
 // with a matching statusCode.
 func ErrorStatus(err error, statusCode int) bool {
-	dberr, ok := err.(*Error)
-	return ok && dberr.StatusCode == statusCode
+	var dberr *Error
+	if xerrors.As(err, &dberr) {
+		return dberr.StatusCode == statusCode
+	}
+	return false
 }
 
 func parseError(resp *http.Response) error {

--- a/http_test.go
+++ b/http_test.go
@@ -47,4 +47,7 @@ func TestErrorHandling(t *testing.T) {
 	if couchdb.Conflict(fe) {
 		t.Errorf("Did not expect a conflict")
 	}
+	if couchdb.Conflict(nil) {
+		t.Errorf("Did not expect a conflict with nil")
+	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -1,8 +1,12 @@
 package couchdb_test
 
 import (
+	"errors"
+	"net/http"
 	. "net/http"
 	"testing"
+
+	couchdb "github.com/cabify/go-couchdb"
 )
 
 type testauth struct{ called bool }
@@ -31,5 +35,16 @@ func TestClientSetAuth(t *testing.T) {
 	}
 	if auth.called {
 		t.Error("AddAuth was called after removing Auth instance")
+	}
+}
+
+func TestErrorHandling(t *testing.T) {
+	te := &couchdb.Error{Method: "GET", StatusCode: http.StatusConflict}
+	fe := errors.New("Not an HTTP error")
+	if !couchdb.Conflict(te) {
+		t.Errorf("Expected conflict")
+	}
+	if couchdb.Conflict(fe) {
+		t.Errorf("Did not expect a conflict")
 	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -3,7 +3,6 @@ package couchdb_test
 import (
 	"errors"
 	"net/http"
-	. "net/http"
 	"testing"
 
 	couchdb "github.com/cabify/go-couchdb"
@@ -11,13 +10,13 @@ import (
 
 type testauth struct{ called bool }
 
-func (a *testauth) AddAuth(*Request) {
+func (a *testauth) AddAuth(*http.Request) {
 	a.called = true
 }
 
 func TestClientSetAuth(t *testing.T) {
 	c := newTestClient(t)
-	c.Handle("HEAD /", func(resp ResponseWriter, req *Request) {})
+	c.Handle("HEAD /", func(resp http.ResponseWriter, req *http.Request) {})
 
 	auth := new(testauth)
 	c.SetAuth(auth)


### PR DESCRIPTION
Using the new error handling that comes with Go 1.13 and xerrors compat library around the CouchDB error testing calls.