### PR TITLE
Add bulk method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,37 @@
 # Cabify CouchDB Library ChangeLog
 
-## 0.3.1
+## [Unreleased]
+### Added
+- BulkDocs method
+
+### Changed
+- Nothing
+
+### Deprecated
+- Nothing
+
+### Removed
+- Nothing
+
+### Fixed
+- Nothing
+
+### Security
+- Nothing
+
+## [0.3.1] - 2020-02-13
 ### Fixed
 - PostView func needs body and query parameters
 
-## 0.3.0
+## [0.3.0] - 2020-02-12
 ### Added
 - PostView method to query views with POST method
 
-## 0.2.0
+## [0.2.0] - 2020-07-09
 ### Added
 - BulkGet method to query multiple documents per id at once
 - go.mod file
 
-## 0.1.0
+## [0.1.0] - 2020-06-19
+### Added
 - First release to be compatible with go modules

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/cabify/go-couchdb"
 	"io"
 	"io/ioutil"
 	. "net/http"
 	"testing"
+
+	"github.com/cabify/go-couchdb"
 )
 
 var (

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,9 +1,10 @@
 package couchdb_test
 
 import (
-	"github.com/cabify/go-couchdb"
 	"net/http"
 	"testing"
+
+	"github.com/cabify/go-couchdb"
 )
 
 func TestBasicAuth(t *testing.T) {

--- a/bulk.go
+++ b/bulk.go
@@ -6,7 +6,7 @@ type bulkID struct {
 	ID string `json:"id"`
 }
 
-type BulkGetReq struct {
+type BulkGet struct {
 	Docs []struct{ ID string } `json:"docs"`
 }
 

--- a/bulk.go
+++ b/bulk.go
@@ -6,8 +6,12 @@ type bulkID struct {
 	ID string `json:"id"`
 }
 
-type BulkGet struct {
+type BulkGetReq struct {
 	Docs []struct{ ID string } `json:"docs"`
+}
+
+type BulkDocsReq struct {
+	Docs []interface{} `json:"docs"`
 }
 
 type errorWrapper struct {
@@ -22,11 +26,19 @@ type docWrapper struct {
 	Error *errorWrapper   `json:"error"`
 }
 
-type bulkRes struct {
+type bulkGetRes struct {
 	Id   string       `json:"id"`
 	Docs []docWrapper `json:"docs"`
 }
 
-type bulkResp struct {
-	Results []bulkRes
+type bulkGetResp struct {
+	Results []bulkGetRes
+}
+
+type BulkDocsResp struct {
+	OK     bool   `json:"ok,omitempty"`
+	ID     string `json:"id"`
+	Rev    string `json:"rev,omitempty"`
+	Error  string `json:"error,omitempty"`
+	Reason string `json:"reason,omitempty"`
 }

--- a/client_test.go
+++ b/client_test.go
@@ -233,7 +233,7 @@ func TestGetNonexistingDoc(t *testing.T) {
 func TestBulkGet(t *testing.T) {
 	c := newTestClient(t)
 	c.Handle("POST /db/_bulk_get", func(resp http.ResponseWriter, req *http.Request) {
-		reqData := couchdb.BulkGetReq{}
+		reqData := couchdb.BulkGet{}
 		body, _ := ioutil.ReadAll(req.Body)
 		err := json.Unmarshal(body, &reqData)
 		check(t, "reqData.Docs[0].ID", "foo", reqData.Docs[0].ID)

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -232,7 +233,7 @@ func TestGetNonexistingDoc(t *testing.T) {
 func TestBulkGet(t *testing.T) {
 	c := newTestClient(t)
 	c.Handle("POST /db/_bulk_get", func(resp http.ResponseWriter, req *http.Request) {
-		reqData := couchdb.BulkGet{}
+		reqData := couchdb.BulkGetReq{}
 		body, _ := ioutil.ReadAll(req.Body)
 		err := json.Unmarshal(body, &reqData)
 		check(t, "reqData.Docs[0].ID", "foo", reqData.Docs[0].ID)
@@ -316,6 +317,71 @@ func TestPut(t *testing.T) {
 		t.Fatal(err)
 	}
 	check(t, "returned rev", "1-619db7ba8551c0de3f3a178775509611", rev)
+}
+
+func TestBulkDocs(t *testing.T) {
+	c := newTestClient(t)
+	c.Handle("POST /db/_bulk_docs", func(rw http.ResponseWriter, req *http.Request) {
+		body, _ := ioutil.ReadAll(req.Body)
+		fmt.Println(string(body))
+		reqData := couchdb.BulkDocsReq{}
+		err := json.Unmarshal(body, &reqData)
+		check(t, "json.Unmarshal", err, nil)
+
+		check(t, "request body", "Barney", reqData.Docs[0].(map[string]interface{})["_id"])
+		check(t, "request body", "Fred Flintstone", reqData.Docs[1].(map[string]interface{})["name"])
+		check(t, "request body", "Pebbles", reqData.Docs[2].(map[string]interface{})["_id"])
+		check(t, "request body", "Dino", reqData.Docs[3].(map[string]interface{})["name"])
+
+		rw.WriteHeader(http.StatusOK)
+		_, err = io.WriteString(rw, `[{"ok":true,"id":"Barney","rev":"1"},
+    		{"ok":true,"id":"Fred","rev":"1"},
+    		{"ok":true,"id":"Pebbles","rev":"2"},
+			{"id":"Dino","error":"conflict","reason":"Document update conflict"}]`)
+		check(t, "io.WriteString", err, nil)
+
+	})
+
+	type createDoc struct {
+		Name string `json:"name"`
+		ID   string `json:"_id"`
+		Rev  string `json:"_rev"`
+	}
+	type updateDoc struct {
+		Name string `json:"name"`
+		Age  int32  `json:"age"`
+	}
+	type delDoc struct {
+		ID      string `json:"_id"`
+		Rev     string `json:"_rev"`
+		Deleted bool   `json:"_deleted"`
+	}
+
+	docCreate := &createDoc{"Barney Rubble", "Barney", "1"}
+	docUpdate := &updateDoc{"Fred Flintstone", 41}
+	docDel := &delDoc{"Pebbles", "2", true}
+	docFailUpdate := &updateDoc{Name: "Dino", Age: 5}
+
+	res, err := c.DB("db").BulkDocs(docCreate, docUpdate, docDel, docFailUpdate)
+	check(t, "BulkDocs", err, nil)
+
+	createRes := res[0]
+	check(t, "createRes.OK", true, createRes.OK)
+	check(t, "createRes.ID", "Barney", createRes.ID)
+	check(t, "createRes.Rev", "1", createRes.Rev)
+
+	updateRes := res[1]
+	check(t, "updateRes.OK", true, updateRes.OK)
+
+	delRes := res[2]
+	check(t, "delRes.OK", true, delRes.OK)
+	check(t, "delRes.ID", "Pebbles", delRes.ID)
+	check(t, "delRes.Rev", "2", delRes.Rev)
+
+	updateFailuteRes := res[3]
+	check(t, "updateFailuteRes.OK", false, updateFailuteRes.OK)
+	check(t, "updateFailuteRes.ID", "Dino", updateFailuteRes.ID)
+	check(t, "updateFailuteRes.Error", "conflict", updateFailuteRes.Error)
 }
 
 func TestPutWithRev(t *testing.T) {

--- a/couchapp/couchapp.go
+++ b/couchapp/couchapp.go
@@ -11,12 +11,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/cabify/go-couchdb"
 	"io/ioutil"
 	"mime"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/cabify/go-couchdb"
 )
 
 // DefaultIgnorePatterns contains the default list of glob patterns

--- a/db.go
+++ b/db.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"reflect"
 	"strings"
 )
@@ -72,7 +73,7 @@ func (db *DB) BulkGet(ids []string, docType interface{}, opts Options) (docs []i
 		return nil, nil, err
 	}
 
-	request := &BulkGet{}
+	request := &BulkGetReq{}
 	for _, id := range ids {
 		request.Docs = append(request.Docs, struct{ ID string }{ID: id})
 	}
@@ -85,7 +86,7 @@ func (db *DB) BulkGet(ids []string, docType interface{}, opts Options) (docs []i
 		return nil, nil, err
 	}
 
-	response := bulkResp{}
+	response := bulkGetResp{}
 	err = readBody(resp, &response)
 	if err != nil {
 		return nil, nil, err
@@ -147,6 +148,48 @@ func (db *DB) Put(id string, doc interface{}, rev string) (newrev string, err er
 	}
 	b := bytes.NewReader(json)
 	return responseRev(db.closedRequest(db.ctx, "PUT", path, b))
+}
+
+// BulkDocs allows to create, update and/or delete multiple documents in a single request.
+// The basic operations are similar to creating or updating a single document,
+// except that they are batched into one request.
+//
+// BulkDocs accepts an array of documents to be processed.
+// Documents may contain _id, _rev and _deleted,
+// depending on the wanted operation,
+// as well as the corresponding document fields if needed.
+//
+// It returns a slice of results with the outcome of every operation or an error.
+// The only mandatory field is the ID.
+// The rest of the structure of the result depends if it was successful or not.
+// Note that no error will be returned if an operation or more fail.
+//
+// Observe that behaviour of two or more operations in a single document is undetermined.
+// There are no guarantees that the operations will be processed in any given order.
+//
+// Reference: https://cloud.ibm.com/docs/Cloudant?topic=Cloudant-documents#bulk-operations
+func (db *DB) BulkDocs(docs ...interface{}) (res []BulkDocsResp, err error) {
+	path := revpath("", db.name, "_bulk_docs")
+
+	var req BulkDocsReq
+	req.Docs = make([]interface{}, 0, len(docs))
+	for _, doc := range docs {
+		req.Docs = append(req.Docs, doc)
+	}
+
+	bodyJSON, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	body := bytes.NewReader(bodyJSON)
+	httpResp, err := db.request(db.ctx, http.MethodPost, path, body)
+
+	err = readBody(httpResp, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }
 
 // Delete marks a document revision as deleted.

--- a/db.go
+++ b/db.go
@@ -73,7 +73,7 @@ func (db *DB) BulkGet(ids []string, docType interface{}, opts Options) (docs []i
 		return nil, nil, err
 	}
 
-	request := &BulkGetReq{}
+	request := &BulkGet{}
 	for _, id := range ids {
 		request.Docs = append(request.Docs, struct{ ID string }{ID: id})
 	}

--- a/x_test.go
+++ b/x_test.go
@@ -4,12 +4,13 @@ package couchdb_test
 
 import (
 	"bytes"
-	"github.com/cabify/go-couchdb"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"github.com/cabify/go-couchdb"
 )
 
 // testClient is a very special couchdb.Client that also implements


### PR DESCRIPTION
BulkDocs allows to create, update and/or delete multiple documents in a single request.
The basic operations are similar to creating or updating a single document,
except that they are batched into one request.