### PR TITLE
Fix BulkGet request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 ### Security
 - Nothing
 
+## [0.4.1] - 2020-08-03
+### Added
+- Fix BulkGet request body
+
 ## [0.4.0] - 2020-08-03
 ### Added
 - BulkDocs method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Nothing
 
 ## [0.4.1] - 2020-08-03
-### Added
+### Fixed
 - Fix BulkGet request body
 
 ## [0.4.0] - 2020-08-03

--- a/bulk.go
+++ b/bulk.go
@@ -7,7 +7,7 @@ type bulkID struct {
 }
 
 type BulkGet struct {
-	Docs []struct{ ID string } `json:"docs"`
+	Docs []bulkID `json:"docs"`
 }
 
 type BulkDocsReq struct {

--- a/db.go
+++ b/db.go
@@ -75,7 +75,7 @@ func (db *DB) BulkGet(ids []string, docType interface{}, opts Options) (docs []i
 
 	request := &BulkGet{}
 	for _, id := range ids {
-		request.Docs = append(request.Docs, struct{ ID string }{ID: id})
+		request.Docs = append(request.Docs, bulkID{ID: id})
 	}
 
 	bodyJson, err := json.Marshal(request)


### PR DESCRIPTION
Use proper json tag in request body.

The IDs parameter lacked a json tag and got marshaled capitalized, but
couch expects it lowercased.