### PR TITLE
Improve error handling in HTTP response parsing

### DIFF
--- a/http.go
+++ b/http.go
@@ -305,7 +305,7 @@ func parseErrorBody(resp *http.Response) (errorCode, reason string) {
 	if err := json.Unmarshal(body, &reply); err != nil {
 		// If JSON parsing fails, use the raw body as the error message
 		bodyStr := string(body)
-		return bodyStr, bodyStr
+		return "unknown", bodyStr
 	}
 
 	// Successfully parsed JSON, use the parsed fields


### PR DESCRIPTION
Problem: When trying to parse a couch db error response, we fail if the error is not a JSON. This gives us confusing errors like:

```json
{
    "Storage": "Couch",
    "id": "9210635f73cbb0a99a9b0ea39d2710a9",
    "level": "error",
    "msg": "Error getting: GET {full_url}: (500) unknown, couldn't decode CouchDB error: unexpected end of JSON input: unknown, couldn't decode CouchDB error: unexpected end of JSON input",
    "spanID": "0c2b57c5a0578c72",
    "time": "2025-11-01T08:26:30.201Z",
    "traceID": "e0eefa2117e7788e2a6f87eb433f8b33"
}
```


Solution: Added a fallback that outputs the response body as a string when JSON parsing fails.